### PR TITLE
Mobile version should not load qrc url for 404 error

### DIFF
--- a/src/mobile/404.html
+++ b/src/mobile/404.html
@@ -1,9 +1,0 @@
-<html>
-<body>
-
-<h1>=(</h1>
-<h2>Snowshoe says: 404! File not found.</h2>
-<h1>=~</h1>
-
-</body>
-</html>

--- a/src/mobile/qml/NavigationPanel.qml
+++ b/src/mobile/qml/NavigationPanel.qml
@@ -40,7 +40,7 @@ Item {
                 onLoadingChanged: {
                     if (loadRequest.status == WebView.LoadFailedStatus) {
                         webViewItem.shouldAnimateIndicator = false
-                        webViewItem.url = "qrc:/mobile/404.html"
+                        webView.loadHtml(UiConstants.HtmlFor404Page)
                     }
                 }
 

--- a/src/mobile/qml/UiConstants.js
+++ b/src/mobile/qml/UiConstants.js
@@ -1,2 +1,3 @@
 
 var DefaultMargin = 32
+var HtmlFor404Page = "<html><body><h1>=(</h1><h2>Snowshoe says: 404! File not found.</h2><h1>=~</h1></body></html>"

--- a/src/mobile/snowshoe-mobile.qrc
+++ b/src/mobile/snowshoe-mobile.qrc
@@ -11,6 +11,5 @@
         <file>qml/main-harmattan.qml</file>
         <file>qml/PanelToggle.qml</file>
         <file>qml/PanelToggleButton.qml</file>
-        <file>404.html</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
We no longer have support for loading qrc urls on WK2, so instead,
we dump the html into a constant and use QQuickWebView's loadHtml.

Reviewed-by: NOBODY
