### PR TITLE
Fix build failure with Qt5's deprecation of QAbstractItemModel::setRoleNames

### DIFF
--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -7,6 +7,8 @@ QT += sql widgets quick
 QMAKE_CFLAGS += -fPIC
 QMAKE_CXXFLAGS += -fPIC
 
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0
+
 SOURCES += \
     ApplicationStateTracker.cpp \
     RowsRangeFilter.cpp \


### PR DESCRIPTION
The proper fix would be more verbose, see [1] lines 56 - 70 for an example. It will be probably easier if you don't care about compiling under Qt4.

[1] https://gitorious.org/trojita/trojita/blobs/c20f293baa5c1e94a4eb56de1251a25cf069b0c0/src/Imap/Model/MailboxModel.cpp#line56
