### PR TITLE
Fix mobile mode with current webkit trunk

### DIFF
--- a/src/mobile/qml/SnowshoeWebView.qml
+++ b/src/mobile/qml/SnowshoeWebView.qml
@@ -52,7 +52,6 @@ Item {
         enabled: webViewItem.active && webViewItem.interactive
 
         experimental.preferredMinimumContentsWidth: 980
-        experimental.devicePixelRatio: 1.5
         experimental.userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3"
 
         onLoadingChanged: {


### PR DESCRIPTION
Last December the property for setting pixel ratio was removed from webkit trunk thanks to qtbase receiving support for devicePixelRatio.

Further details on webkit issue #104574.
